### PR TITLE
LCE-6739 add Dockerfile to nodejs service

### DIFF
--- a/nodehog-stress-10-destress-0/Dockerfile
+++ b/nodehog-stress-10-destress-0/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:lts-alpine
+
+WORKDIR /app/
+
+COPY package.json package-lock.json /app/
+RUN npm ci --only=production
+
+COPY . /app/
+
+CMD [ "npm", "start" ]

--- a/nodehog/Dockerfile
+++ b/nodehog/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:lts-alpine
+
+WORKDIR /app/
+
+COPY package.json package-lock.json /app/
+RUN npm ci --only=production
+
+COPY . /app/
+
+CMD [ "npm", "start" ]


### PR DESCRIPTION
This additional dockerfile is needed to change nodejs service to be a recipe type docker.